### PR TITLE
TOC Level

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Encoding: UTF-8
 URL: https://github.com/Public-Health-Scotland/phstemplates
 BugReports: https://github.com/Public-Health-Scotland/phstemplates/issues
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Suggests: 
     rstudioapi,
     dplyr,
@@ -20,11 +20,11 @@ Suggests:
     lubridate,
     ggplot2,
     janitor,
+    flextable (>= 0.5.7),
+    captioner,
     gdtools
 Imports: 
     magrittr,
     rmarkdown,
-    captioner,
-    flextable (>= 0.5.7),
     officer,
     renv

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -20,7 +20,8 @@ compile_report <- function(rmd_filename = list.files(pattern = "\\.Rmd$")[1],
                            subtitle = "My Subtitle",
                            date = "DD Month YYYY",
                            filename_out = "Report_and_Cover.docx",
-                           auto_open = TRUE) {
+                           auto_open = TRUE,
+                           toc_level = 3) {
 
   rmd_exists <- file.exists(rmd_filename)
   cover_exists <- file.exists(cover_filename)
@@ -50,7 +51,7 @@ compile_report <- function(rmd_filename = list.files(pattern = "\\.Rmd$")[1],
 
     officer::read_docx("temp_report.docx") %>%
       officer::cursor_reach(keyword = "Introduction") %>%
-      officer::body_add_toc(pos = "before") %>%
+      officer::body_add_toc(pos = "before", level = toc_level) %>%
       officer::body_add_par("Contents", pos = "before", style = "TOC Heading") %>%
       officer::cursor_reach(keyword = "Introduction") %>%
       officer::body_add_break(pos = "before") %>%

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -8,7 +8,7 @@
 #' @param date Date of Publication.
 #' @param filename_out Output filename for compiled report.
 #' @param auto_open Automatically open the report after it is compiled?
-#' @param toc_level Option to change the levels in the table of contents
+#' @param toc_level Maximum title level to use for table of contents.
 #' @return Report with table of contents and front cover included in docx format.
 #' @export
 #' @examples

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -8,6 +8,7 @@
 #' @param date Date of Publication.
 #' @param filename_out Output filename for compiled report.
 #' @param auto_open Automatically open the report after it is compiled?
+#' @param toc_level Option to change the levels in the table of contents
 #' @return Report with table of contents and front cover included in docx format.
 #' @export
 #' @examples

--- a/man/compile_report.Rd
+++ b/man/compile_report.Rd
@@ -11,7 +11,8 @@ compile_report(
   subtitle = "My Subtitle",
   date = "DD Month YYYY",
   filename_out = "Report_and_Cover.docx",
-  auto_open = TRUE
+  auto_open = TRUE,
+  toc_level = 3
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ compile_report(
 \item{filename_out}{Output filename for compiled report.}
 
 \item{auto_open}{Automatically open the report after it is compiled?}
+
+\item{toc_level}{Maximum title level to use for table of contents.}
 }
 \value{
 Report with table of contents and front cover included in docx format.


### PR DESCRIPTION
Add table of contents level argument to compile report
Allows user to input number of levels to display in their output, but default still set to 3 as before. 