### PR TITLE
Expand the gitignore template

### DIFF
--- a/inst/text/gitignore.txt
+++ b/inst/text/gitignore.txt
@@ -8,6 +8,7 @@ data/
 
 # Common text files that may contain data #
 *.[cC][sS][vV]
+*.[cC][sS][vV].*
 *.[tT][xX][tT]
 
 # Excel files #

--- a/inst/text/gitignore.txt
+++ b/inst/text/gitignore.txt
@@ -22,5 +22,10 @@ data/
 *.[rR][dD][aA][tT][aA]
 *.[rR][dD][sS]
 
+# Cross platform data files #
+*.[pP][aA][rR][qQ][uU][eE][tT]
+*.[fF][sS][tT]
+*.[qQ][sQ]
+
 # MacOS folder attributes files #
 .DS_Store

--- a/inst/text/gitignore.txt
+++ b/inst/text/gitignore.txt
@@ -2,6 +2,7 @@
 .Rhistory
 .RData
 .Ruserdata
+*.Rproj
 
 # 'data' folder #
 data/

--- a/inst/text/gitignore.txt
+++ b/inst/text/gitignore.txt
@@ -25,7 +25,7 @@ data/
 # Cross platform data files #
 *.[pP][aA][rR][qQ][uU][eE][tT]
 *.[fF][sS][tT]
-*.[qQ][sQ]
+*.[qQ][sS]
 
 # MacOS folder attributes files #
 .DS_Store


### PR DESCRIPTION
I've added a line which should catch any compressed CSV files - We use `.csv.gz` on our team sometimes. `readr` and others are capable of reading a zipped CSV file too.

I've also added three 'modern' file types, we've been using `.fs` files for a while but on the new PWB infrastructure `.parquet` is super useful for many reasons! `.qs` is basically a better version of `.rds` in that it can store any R object, however, it's missing features that `.parquet` and `.fs` have when dealing with data.frames