### PR TITLE
CSS Template - update hyperlinks styles

### DIFF
--- a/inst/text/phs_style.css
+++ b/inst/text/phs_style.css
@@ -60,12 +60,22 @@ body {
     background-color: var(--white);
   }
 
-/* Style hyperlinks */
-.externallink {color: var(--phs-purple); font-weight: bold;}
-.externallink:hover {color: var(--phs-teal-50);}
+/* Style external links */
+.externallink {
+  color: var(--phs-purple);
+  font-weight: bold;
+}
+.externallink:hover {
+  color: var(--phs-teal-50);
 
-a {color: var(--phs-purple); font-weight: bold;}
-a:hover {color: var(--phs-teal-50);}
+}
+/* Style in-line hyperlinks (e.g., rmarkdowns using [text](link)) */
+a {
+  color: var(--phs-purple);
+  font-weight: bold;}
+a:hover {
+  color: var(--phs-teal-50);
+}
 
 /* Table of Contents */
 .tocify {

--- a/inst/text/phs_style.css
+++ b/inst/text/phs_style.css
@@ -64,6 +64,9 @@ body {
 .externallink {color: var(--phs-purple); font-weight: bold;}
 .externallink:hover {color: var(--phs-teal-50);}
 
+a {color: var(--phs-purple); font-weight: bold;}
+a:hover {color: var(--phs-teal-50);}
+
 /* Table of Contents */
 .tocify {
     width: 20%;

--- a/inst/text/phs_style.css
+++ b/inst/text/phs_style.css
@@ -107,7 +107,7 @@ a:hover {color: var(--phs-teal-50);}
   .btn-default.hover, .btn-default:hover, .btn-default.focus,
   .btn-default:focus {
     background-color: var(--phs-purple-10);
-    border-color: var(phs-purple);
+    border-color: var(--phs-purple);
 }
 
 /* tabset panel update, pills style in phs colours */


### PR DESCRIPTION
`.externallink` is a css class that is only used in some instances, but most instances uses the class `a`. We had discussed this initially, but thought the former would cover everything (wrongly).
I have tested the new css styles and this applies the appropriate, phs branding to hyperlinks in rmarkdowns that use in-line hyperlinks, by using the formula: (text explaining link)[hyperlink.com]

Also I spotted a bug in btn border styles which I've fixed.  (missing the "--" in the var() to call phs-purple). 